### PR TITLE
Add configuration file support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,10 @@
 name: CI 
 
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - main
   pull_request:
+  push:
+    tags: [v*]
+    branches: [main]
 
 permissions:
   contents: write
@@ -21,10 +19,10 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: ~1.17
+          go-version: ~1.18
 
       - name: Lint 
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           skip-go-installation: true
           args: --timeout=5m
@@ -79,8 +77,7 @@ jobs:
         run: |
           cd dist
           jfrog rt upload "*_x86_64.deb" "debian-dev/pool/main/g/" --deb="stretch,buster,bullseye/main/amd64"
-          jfrog rt upload "*_386.deb" "debian-dev/pool/main/g/" --deb="stretch,buster,bullseye/main/i386"
-          jfrog rt upload "*_arm64.deb" "debian-dev/pool/main/g/" --deb="stretch,buster,bullseye/main/amd64"
+          jfrog rt upload "*_aarch64.deb" "debian-dev/pool/main/g/" --deb="stretch,buster,bullseye/main/amd64"
 
       - name: Publish build
         uses: ./_actions/jfrog/publish

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,14 +12,15 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - arm64
+      - amd64
 
 archives:
+  # Match uname -m output for easy retrieval
   - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
       amd64: x86_64
+      arm64: aarch64
 checksum:
   name_template: 'checksums.txt'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.46.1
+    hooks:
+      - id: golangci-lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # get-secret 
 
-**get-secret** is a small program that gets secrets from AWS Secrets Manager and parameters from SSM Parameter Store.
+**get-secret** is a small program that gets secrets from AWS Secrets Manager
+and parameters from SSM Parameter Store.
 
 ## Use
 
@@ -16,10 +17,20 @@ positional arguments:
 optional arguments:
   --secretsmanager use AWS Secrets Manager (default)
   --ssm            use SSM Parameter Store
+  --conf           load secrets from configuration file ("-" for stdin)
+  -v               show verbose logging 
+
+configuration file example:
+  # source_path        destination_path                   owner group    permissions source_service
+  /mitra/myapp/secrets /etc/secrets-internal/secrets.json root  www-data 0640
+  /mitra/myapp/param   /etc/secrets-internal/param.txt    root  www-data 0640        ssm`
 ```
 
 ### Notes
 
-If you are attempting to **get-secrets** on a machine with AWS credentials from the environment, such as when using bobafett or awsume, then you must set `AWS_SDK_LOAD_CONFIG` to a truthy value for credentials loading to work. See [sdk-for-go's session documentation][session] for more information.
+If you are attempting to **get-secrets** on a machine with AWS credentials from
+the environment, such as when using aws sso or awsume, then you must set
+`AWS_SDK_LOAD_CONFIG` to a truthy value for credentials loading to work. See
+[sdk-for-go's session documentation][session] for more information.
 
 [session]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/

--- a/aws.go
+++ b/aws.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"sync"
 
@@ -17,11 +18,13 @@ var (
 // Singleton AWS Session
 func GetAwsSession() *session.Session {
 	once.Do(func() {
+		log.Println("creating AWS session")
 		var err error
 		sess, err = CreateAwsSession()
 		if err != nil {
 			panic(err)
 		}
+		log.Printf("session created in %s", *sess.Config.Region)
 	})
 	return sess
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module bitbucket.org/lindenlabinternal/get-secret
 
-go 1.16
+go 1.18
 
-require github.com/aws/aws-sdk-go v1.44.9
+require (
+	github.com/aws/aws-sdk-go v1.44.9
+	github.com/mattn/go-isatty v0.0.14
+)
+
+require (
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,16 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/main.go
+++ b/main.go
@@ -1,72 +1,89 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"log"
 	"os"
+	"os/user"
+	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
+
+	"github.com/mattn/go-isatty"
 )
 
-const usage = `usage: get-secret [--ssm|--secretsmanager] NAME [VERSION]
+const usage = `usage: get-secret [--ssm|--secretsmanager|--conf] NAME [VERSION]
 
 Fetch values from AWS Secrets Manager and SSM Parameter Store.
 
 positional arguments:
-  NAME     secret or parameter name
+  NAME     secret, parameter or conf file name
   VERSION  secret version, used by Secrets Manager only. Default = AWSCURRENT
 
 optional arguments:
   --secretsmanager use AWS Secrets Manager (default)
-  --ssm            use SSM Parameter Store`
+  --ssm            use SSM Parameter Store
+  --conf           load secrets from configuration file ("-" for stdin)
+  -v               show verbose logging 
+  
+configuration file example:
+  # source_path        destination_path                   owner group    permissions source_service
+  /mitra/myapp/secrets /etc/secrets-internal/secrets.json root  www-data 0640
+  /mitra/myapp/param   /etc/secrets-internal/param.txt    root  www-data 0640        ssm`
 
 type SecretProvider interface {
-	GetSecret(i GetSecretInput) (*GetSecretOutput, error)
+	GetSecret(i GetSecretInput) ([]byte, error)
 }
 
 type SecretsManagerProvider struct{}
 type ParameterStoreProvider struct{}
 type CombinedProvider struct{}
 
-func (p *SecretsManagerProvider) GetSecret(i GetSecretInput) (*GetSecretOutput, error) {
+func (p *SecretsManagerProvider) GetSecret(i GetSecretInput) ([]byte, error) {
 	svc := secretsmanager.New(GetAwsSession())
 	input := &secretsmanager.GetSecretValueInput{
 		SecretId:     aws.String(i.Name),
 		VersionStage: aws.String(i.Version),
 	}
+	log.Printf("secretsmanager: getting %s", i.Name)
 	res, err := svc.GetSecretValue(input)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &GetSecretOutput{
-		Binary: res.SecretBinary,
-		String: res.SecretString,
-	}, nil
+	if res.SecretString != nil {
+		return []byte(*res.SecretString), nil
+	}
+	return res.SecretBinary, nil
 }
 
-func (p *ParameterStoreProvider) GetSecret(i GetSecretInput) (*GetSecretOutput, error) {
+func (p *ParameterStoreProvider) GetSecret(i GetSecretInput) ([]byte, error) {
 	svc := ssm.New(GetAwsSession())
 	input := &ssm.GetParameterInput{
 		Name:           aws.String(i.Name),
 		WithDecryption: aws.Bool(true),
 	}
+	log.Printf("ssm: getting %s", i.Name)
 	res, err := svc.GetParameter(input)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &GetSecretOutput{
-		String: res.Parameter.Value,
-	}, nil
+	return []byte(*res.Parameter.Value), nil
 }
 
-func (p *CombinedProvider) GetSecret(i GetSecretInput) (*GetSecretOutput, error) {
+func (p *CombinedProvider) GetSecret(i GetSecretInput) ([]byte, error) {
 	switch i.Source {
 	case SecretsManager:
 		return (&SecretsManagerProvider{}).GetSecret(i)
@@ -79,38 +96,149 @@ func (p *CombinedProvider) GetSecret(i GetSecretInput) (*GetSecretOutput, error)
 	}
 }
 
-type SecretSource int
-
 const (
-	SecretsManager SecretSource = iota
-	ParameterStore
-	Combined
+	AWSCURRENT     = "AWSCURRENT"
+	SecretsManager = "secretsmanager"
+	ParameterStore = "ssm"
+	Combined       = "combined"
 )
 
 type GetSecretInput struct {
 	Name    string
 	Version string
-	Source  SecretSource
+	Source  string
 }
 
-type GetSecretOutput struct {
-	String *string
-	Binary []byte
+type SecretLoader struct {
+	provider SecretProvider
 }
 
-func run(args []string, provider SecretProvider) int {
+func (s *SecretLoader) FromConfFile(path string) error {
+	var r io.Reader
+	if path == "-" {
+		r = os.Stdin
+	} else {
+		r, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("Unable to open %s", path)
+		}
+		defer r.Close()
+	}
+	return s.FromConf(r)
+}
+
+func (s *SecretLoader) FromConf(conf io.Reader) error {
+	n := 0
+	scanner := bufio.NewScanner(conf)
+	for scanner.Scan() {
+		n++
+		ln := scanner.Text()
+		// Skip comments
+		if strings.HasPrefix(ln, "#") {
+			continue
+		}
+		fields := strings.Fields(ln)
+		// Skip empty lines
+		if len(fields) == 0 {
+			continue
+		}
+		if len(fields) < 5 {
+			return fmt.Errorf("Line %d has an incorrect number of fields. Need: NAME DST OWNER GROUP PERMISSIONS [SOURCE]", n)
+		}
+		name := fields[0]
+		dst := fields[1]
+		username := fields[2]
+		groupname := fields[3]
+		perms := fields[4]
+		src := SecretsManager
+		if len(fields) > 5 {
+			src = fields[5]
+		}
+
+		res, err := s.provider.GetSecret(GetSecretInput{
+			Name:    name,
+			Version: AWSCURRENT,
+			Source:  src,
+		})
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Create(dst)
+		if err != nil {
+			return err
+		}
+		if _, err = f.Write(res); err != nil {
+			return err
+		}
+		f.Close()
+
+		// Lookup user by name or id
+		owner, err := user.Lookup(username)
+		if err != nil {
+			if owner, err = user.LookupId(username); err != nil {
+				return fmt.Errorf("unknown user or uid %s", username)
+			}
+		}
+
+		// Lookup group by name or id
+		group, err := user.LookupGroup(groupname)
+		if err != nil {
+			if group, err = user.LookupGroupId(groupname); err != nil {
+				return fmt.Errorf("unknown group or gid %s", groupname)
+			}
+		}
+
+		uid, err := strconv.Atoi(owner.Uid)
+		if err != nil {
+			return err
+		}
+
+		gid, err := strconv.Atoi(group.Gid)
+		if err != nil {
+			return err
+		}
+		if err = os.Chown(dst, uid, gid); err != nil {
+			return err
+		}
+
+		// Parse octal
+		mode, err := strconv.ParseInt(perms, 8, 64)
+		if err != nil {
+			return err
+		}
+
+		// Set permissions
+		if err = os.Chmod(dst, fs.FileMode(mode)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func run(args []string, out io.Writer, provider SecretProvider) int {
 	f := flag.NewFlagSet(args[0], flag.ExitOnError)
 	f.Usage = func() {
-		fmt.Println(usage)
+		if _, err := flag.CommandLine.Output().Write([]byte(usage)); err != nil {
+			panic(err)
+		}
 	}
 
 	// Help text not supplied as we are using a custom usage function.
 	useSsm := f.Bool("ssm", false, "")
+	useConf := f.Bool("conf", false, "")
+	verbose := f.Bool("v", false, "")
 	f.Bool("secretsmanager", true, "")
 
 	err := f.Parse(args[1:])
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
+	}
+
+	if *verbose {
+		log.SetOutput(out)
+	} else {
+		log.SetOutput(ioutil.Discard)
 	}
 
 	narg := f.NArg()
@@ -120,39 +248,45 @@ func run(args []string, provider SecretProvider) int {
 	}
 
 	name := f.Arg(0)
-	version := "AWSCURRENT"
-	source := SecretsManager
 
-	if narg > 1 {
-		version = f.Arg(1)
-	}
-
-	if *useSsm {
-		source = ParameterStore
-	}
-
-	res, err := provider.GetSecret(GetSecretInput{
-		Name:    name,
-		Version: version,
-		Source:  source,
-	})
-
-	if err != nil {
-		fmt.Println(err.Error())
-		return 1
-	}
-
-	if res.Binary != nil && len(res.Binary) > 0 {
-		os.Stdout.Write(res.Binary)
-	} else if res.String != nil {
-		fmt.Println(*res.String)
+	if *useConf {
+		l := &SecretLoader{provider}
+		if err = l.FromConfFile(name); err != nil {
+			log.Fatal(err)
+		}
 	} else {
-		fmt.Println("Secret response had no value.")
-		return 1
+		version := AWSCURRENT
+		source := SecretsManager
+
+		if narg > 1 {
+			version = f.Arg(1)
+		}
+
+		if *useSsm {
+			source = ParameterStore
+		}
+
+		res, err := provider.GetSecret(GetSecretInput{
+			Name:    name,
+			Version: version,
+			Source:  source,
+		})
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if _, err := out.Write(res); err != nil {
+			log.Fatal(err)
+		}
 	}
 	return 0
 }
 
 func main() {
-	os.Exit(run(os.Args, &CombinedProvider{}))
+	ret := run(os.Args, os.Stdout, &CombinedProvider{})
+	if ret == 0 && isatty.IsTerminal(os.Stdout.Fd()) {
+		os.Stdout.Write([]byte("\n"))
+	}
+	os.Exit(ret)
 }


### PR DESCRIPTION
This changeset adds support for a configuration file format that [matches DGI's](https://github.com/secondlife/docker-basics/tree/4b84e969bdc93e3b899f99e528596c14fe2d3f02#secrets):

```
# source_path        destination_path                   owner group    permissions source_service
/mitra/myapp/secrets /etc/secrets-internal/secrets.json root  www-data 0640
/mitra/myapp/param   /etc/secrets-internal/param.txt    root  www-data 0640        ssm
```

The purpose of this change is to ease secrets management in environments without DGI's entrypoint scripts. This can be useful with docker images such as alpine, which may not contain bash, or in distroless images (scratch, [google's](https://github.com/GoogleContainerTools/distroless), et al.)