### PR TITLE
Release Debian packages to Artifactory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Lint 
         uses: secondlife-3p/golangci-lint-action@v3
         with:
-          skip-go-installation: true
           args: --timeout=5m
       
       - name: Test
@@ -36,24 +35,38 @@ jobs:
           go mod tidy
           go test -v
 
+      - name: Choose GoReleaser args
+        env:
+          IS_TAG: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        id: goreleaser-args
+        run: |
+          if [[ "$IS_TAG" == "true" ]]
+          then
+            echo "Building for a tag: do a fully regular gorelease" >&2
+            echo "value=" >> $GITHUB_OUTPUT
+          else
+            echo "Not building for a tag: do the gorelease in snapshot mode" >&2
+            echo "value=--snapshot" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        if: success() && startsWith(github.ref, 'refs/tags/v')
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release ${{ steps.goreleaser-args.outputs.value }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: secondlife/action-upload-packages@v1
         with:
-          target: dist/*_x86_64.deb
+          target: dist/*_amd64.deb
           deb-arch: amd64
           deb-releases: stretch,buster,bullseye
 
       - uses: secondlife/action-upload-packages@v1
         with:
-          target: dist/*_aarch64.deb
+          target: dist/*_arm64.deb
           deb-arch: arm64
           deb-releases: stretch,buster,bullseye
       
@@ -66,5 +79,5 @@ jobs:
 
       - uses: secondlife/action-finish-build@v1
         with:
-          promote-if: startsWith(github.ref, 'refs/tags/v')
+          promote-if: ${{ startsWith(github.ref, 'refs/tags/v') }}
           promote: debian-prod

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ nfpms:
   - id: get-secret
     package_name: get-secret-linden
     vendor: Linden Research, Inc.
-    homepage: https://github.com/secondlife/get-secret-cli
+    homepage: https://github.com/secondlife/get-secret
     maintainer: Platform Engineering <platform@lindenlab.com>
     description: Fetch AWS secrets and parameters
     formats:


### PR DESCRIPTION
Hiya. When I tried to release v1.0.1 from #59, I found out I had [goofed up the Go dependency upgrade](https://github.com/secondlife/get-secret/actions/runs/3886088892/jobs/6630774667#step:9:30). Here are the build changes from #59 but on their own, without the Go dependency upgrade.

Ideally this is the kind of thing running goreleaser against the pull request would tell us, but since `goreleaser release --snapshot` says:

> Generate an unversioned snapshot release, skipping all validations and without publishing any artifacts (implies `--skip-publish`, `--skip-announce` and `--skip-validate`)

and there's no `--validate-anyway` arg, I guess we can't do exactly that. 😢 

We can still fancy up the action & update Go dependencies for v1.0.1, but let's review & merge them on their own maybe.